### PR TITLE
Adjuested 'Body' gap and 'Editor' padding to get all Sections Titles in a line

### DIFF
--- a/src/components/Body/Body.module.css
+++ b/src/components/Body/Body.module.css
@@ -81,7 +81,7 @@
 .main {
   display: flex;
   /* flex-direction: column; */
-  gap: 30px;
+  gap: 20px;
   width: 100%;
   justify-content: space-between;
 }

--- a/src/components/Editor/Editor.module.css
+++ b/src/components/Editor/Editor.module.css
@@ -29,7 +29,7 @@
 }
 
 .header .section {
-  padding: 10px;
+  padding: 10px 8px;
   border-bottom: 2px solid transparent;
   font-weight: 500;
   font-size: 1rem;


### PR DESCRIPTION
**Before:**
![image](https://user-images.githubusercontent.com/31766648/198976669-ff480827-4d11-48b9-8529-a95ca2ae1487.png)

**After:**
![image](https://user-images.githubusercontent.com/31766648/198976725-36fefb0d-1c90-44ea-bcb1-89f42e33783b.png)
